### PR TITLE
Add OLE token based on Arbitrum

### DIFF
--- a/models/prices/arbitrum/prices_arbitrum_tokens.sql
+++ b/models/prices/arbitrum/prices_arbitrum_tokens.sql
@@ -103,5 +103,6 @@ FROM
     ("grain-granary","arbitrum","GRAIN","0x80bb30d62a16e1f2084deae84dc293531c3ac3a1",18),
     ("oath-oath","arbitrum","OATH","0xa1150db5105987cec5fd092273d1e3cbb22b378b",18),
     ("winr-winr-protocol","arbitrum","WINR","0xd77b108d4f6cefaa0cae9506a934e825becca46e",18),
-    ("ram-ramses-exchange","arbitrum","RAM","0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",18)
+    ("ram-ramses-exchange","arbitrum","RAM","0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418",18),
+    ("ole-openleverage", "arbitrum", "OLE", "0xd4d026322c88c2d49942a75dff920fcfbc5614c1", 18)
 ) as temp (token_id, blockchain, symbol, contract_address, decimals)

--- a/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
+++ b/models/tokens/arbitrum/tokens_arbitrum_erc20.sql
@@ -118,4 +118,5 @@ FROM (VALUES
         ,('0x7a5D193fE4ED9098F7EAdC99797087C96b002907', 'plsARB', 18)
         ,('0x088cd8f5eF3652623c22D48b1605DCfE860Cd704', 'VELA', 18)
         ,('0xd77b108d4f6cefaa0cae9506a934e825becca46e', 'WINR', 18)
+        ,('0xd4d026322c88c2d49942a75dff920fcfbc5614c1', 'OLE', 18)
      ) AS temp_table (contract_address, symbol, decimals)

--- a/models/tokens/ethereum/tokens_ethereum_erc20.sql
+++ b/models/tokens/ethereum/tokens_ethereum_erc20.sql
@@ -26958,4 +26958,5 @@ FROM (VALUES
         ,('0x421a312d1c443faa673ae47338c0c42fb40cdfd0', 'YAH', 9)
         ,('0xb25ea095997f5bbaa6cea962c4fbf3bfc3c09776', 'FIRE', 9)
         ,('0xa0c7dc8dd85d7366a61b167c5aa42242801a9256', 'BNB', 9)
+        ,('0x92cfbec26c206c90aee3b7c66a9ae673754fab7e', 'OLE', 18)
      ) AS temp_table (contract_address, symbol, decimals)


### PR DESCRIPTION
Brief comments on the purpose of your changes:

**For Dune Engine V2**

I've checked that:

### General checks:
* [ ] I tested the query on dune.com after compiling the model with dbt compile (compiled queries are written to the target directory)
* [ ] I used "refs" to reference other models in this repo and "sources" to reference raw or decoded tables 
* [ ] if adding a new model, I added a test
* [ ] the filename is unique and ends with .sql
* [ ] each sql file is a select statement and has only one view, table or function defined  
* [ ] column names are `lowercase_snake_cased`
* [ ] if adding a new model, I edited the dbt project YAML file with new directory path for both models and seeds (if applicable)
* [ ] if wanting to expose a model in the UI (Dune data explorer), I added a post-hook in the JINJA config to add metadata (blockchains, sector/project, name and contributor Dune usernames)

### Pricing checks:
* [ ] `coin_id` represents the ID of the coin on coinpaprika.com
* [ ] all the coins are active on coinpaprika.com (please remove inactive ones)

### Join logic:
* [ ] if joining to base table (i.e. ethereum transactions or traces), I looked to make it an inner join if possible

### Incremental logic:
* [ ] I used is_incremental & not is_incremental jinja block filters on both base tables and decoded tables
  * [ ] where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to base table (i.e. ethereum transactions or traces), I applied join condition where block_time >= date_trunc("day", now() - interval '1 week')
* [ ] if joining to prices view, I applied join condition where minute >= date_trunc("day", now() - interval '1 week')
